### PR TITLE
[공통] IndentSize가 커밋시 4칸이 되는 문제 수정

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,14 +3,13 @@
 # top-most EditorConfig file
 root = true
 
-# Tab indentation
 [*]
-indent_style = tab
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
 trim_trailing_whitespace = true
 
-# The indent size used in the `package.json` file cannot be changed
-# https://github.com/npm/npm/pull/3180#issuecomment-16336516
-
-[{*.yml,*.yaml,package.json}]
-indent_style = space
+[*.{js,jsx,ts,tsx,css,json,yml,yaml}]
 indent_size = 2

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,26 +2,30 @@ import { useState } from "react";
 import "./App.css";
 
 function App() {
-	const [count, setCount] = useState(0);
+  const [count, setCount] = useState(0);
+  const [isToggle, setIsToggle] = useState(false);
 
-	return (
-		<>
-			<div>
-				<a href="https://vite.dev" target="_blank"></a>
-				<a href="https://react.dev" target="_blank"></a>
-			</div>
-			<h1>Vite + React</h1>
-			<div className="card">
-				<button onClick={() => setCount((count) => count + 1)}>
-					count is {count}
-				</button>
-				<p>내용수정테스트</p>
-			</div>
-			<p className="read-the-docs">
-				Click on the Vite and React logos to learn more
-			</p>
-		</>
-	);
+  return (
+    <>
+      <div>
+        <a href="https://vite.dev" target="_blank"></a>
+        <a href="https://react.dev" target="_blank"></a>
+      </div>
+      <h1>Vite + React</h1>
+      <div className="card">
+        <button onClick={() => setCount((count) => count + 1)}>
+          count is {count}
+        </button>
+        <button onClick={() => setIsToggle((prev) => !prev)}>
+          {isToggle ? "ON" : "OFF"}
+        </button>
+        <p>내용수정테스트</p>
+      </div>
+      <p className="read-the-docs">
+        Click on the Vite and React logos to learn more
+      </p>
+    </>
+  );
 }
 
 export default App;


### PR DESCRIPTION
## 🔍 이슈

.editorconfig 내부에서 ts, js 파일등에 대한 tabSize 를 설정해주지 않아서 github에 올라가는 코드들의 tabSize가 4가 되는 문제가 있었습니다.

## 📗 작업 내역

```text
# EditorConfig is awesome: https://EditorConfig.org

# top-most EditorConfig file
root = true

[*]
charset = utf-8
indent_style = space
indent_size = 2
end_of_line = lf
insert_final_newline = true
trim_trailing_whitespace = true

[*.{js,jsx,ts,tsx,css,json,yml,yaml}]
indent_size = 2
```
`[*.{js,jsx,ts,tsx,css,json,yml,yaml}]` 를 이용하여 해당 파일들에 대한 TabSize를 2로 맞춰줘서 문제를 수정하고자 하였습니다.

## 📋 PR 유형

- [ ] 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [x] 코드에 영향을 주지 않은 변경 사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [x] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 파일 혹은 폴더 추가