### PR TITLE
[BE] - Access 토큰에서 userId를 파싱하도록 수정

### DIFF
--- a/backend/src/auth/user.controller.ts
+++ b/backend/src/auth/user.controller.ts
@@ -11,7 +11,7 @@ import {
 } from "@nestjs/common";
 import { Request, Response } from "express";
 import { ApiBody, ApiOperation } from "@nestjs/swagger";
-import { JwtUserAuthGuard } from "src/utils/guards/http-user-authenticated.guard";
+// import { JwtUserAuthGuard } from "src/utils/guards/http-user-authenticated.guard";
 import { JwtGuestAuthGuard } from "src/utils/guards/http-guest-authenticated.guard";
 import { UserService } from "./user.service";
 import { SignUpUserRequestDto } from "./dto/sign-up-user.dto";
@@ -91,14 +91,10 @@ export class UserController {
   }
 
   @ApiOperation({ summary: "사용자 정보 조회" })
-  @UseGuards(JwtUserAuthGuard)
-  @Get("/:userId")
-  async getUserInfo(
-    @Param("userId") userId: number,
-    @Req() req: Request,
-    @Res() res: Response,
-  ) {
-    const result = await this.userService.getUserInfo(req["user"], userId);
+  @UseGuards(JwtGuestAuthGuard)
+  @Get("/userInfo")
+  async getUserInfo(@Req() req: Request, @Res() res: Response) {
+    const result = await this.userService.getUserInfo(req);
     return res.status(HttpStatus.CREATED).json({
       status: HttpStatus.OK,
       data: {
@@ -128,6 +124,25 @@ export class UserController {
     @Res() res: Response,
   ) {
     const result = await this.userService.checkNicknameExists(body);
+    return res.status(HttpStatus.CREATED).json({
+      status: HttpStatus.OK,
+      data: {
+        message: "OK",
+        ...result,
+      },
+    });
+  }
+
+  // 테스트용 API
+  @ApiOperation({ summary: "특정 사용자 duck 업데이트" })
+  @UseGuards(JwtGuestAuthGuard)
+  @Get("/updateDuck/:duck")
+  async updateDuck(
+    @Req() req: Request,
+    @Res() res: Response,
+    @Param("duck") duck: number,
+  ) {
+    const result = await this.userService.updateDuck(req, duck);
     return res.status(HttpStatus.CREATED).json({
       status: HttpStatus.OK,
       data: {

--- a/backend/src/auth/user.service.ts
+++ b/backend/src/auth/user.service.ts
@@ -100,9 +100,10 @@ export class UserService {
     return { accessToken, nickname, role };
   }
 
-  async getUserInfo(currentUser: object, userId: number) {
+  async getUserInfo(req: Request) {
     // TODO: 사용자 인증 필요, 자신의 정보만 조회 가능하도록
-    console.log(currentUser);
+    console.log(req["user"]);
+    const userId = req["user"].id;
 
     const cachedUserInfo = await this.redisManager.getUser(String(userId));
     if (cachedUserInfo?.nickname) {
@@ -151,5 +152,26 @@ export class UserService {
     const clientIp =
       request.headers["x-forwarded-for"] || request.connection.remoteAddress;
     return "guest-" + clientIp;
+  }
+
+  // 테스트용 메서드
+  async updateDuck(req: Request, duck: number) {
+    const userId = req["user"].id;
+    const role = req["user"].role;
+    const user = await this.redisManager.getUser(String(userId));
+    if (role === "user") await this.userRepository.update(userId, { duck });
+    // await this.redisManager.setUser({
+    //   ...user,
+    //   userId: userId,
+    // });
+    const newUserInfo = {
+      userId: userId,
+      nickname: user.nickname,
+      role: user.role,
+      duck: duck,
+    };
+    await this.redisManager.setUser(newUserInfo);
+
+    return newUserInfo;
   }
 }


### PR DESCRIPTION
## 🔍 이슈

## 📗 작업 내역

- 유저 정보 조회 기능에서 Access 토큰에서 userId를 파싱 및 사용하도록 수정
- 테스트를 위해 특정 사용자의 duck 코인을 업데이트 하는 API 추가


> 구현한 작업 내역

## 📸 스크린샷 (Optional)

| 기능 | 스크린샷 |
| ---- | -------- |
|      |          |

## 📋 PR 유형

- [X] 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않은 변경 사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [X] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 파일 혹은 폴더 추가

## ⚠️ 추가적으로 설명할 내용
