### PR TITLE
[BE] 베팅룸 삭제 API 구현, 회원 엔티티 수정, DB 초기화

### DIFF
--- a/backend/src/auth/user.entity.ts
+++ b/backend/src/auth/user.entity.ts
@@ -3,23 +3,21 @@ import {
   Column,
   Entity,
   PrimaryGeneratedColumn,
-  Unique,
   OneToMany,
   CreateDateColumn,
 } from "typeorm";
 import { Bet } from "src/bet/bet.entity";
 import { BetRoom } from "src/bet-room/bet-room.entity";
 
-@Entity()
-@Unique(["email", "nickname"])
+@Entity("users")
 export class User extends BaseEntity {
   @PrimaryGeneratedColumn("increment")
   id: number;
 
-  @Column()
+  @Column({ unique: true })
   email: string;
 
-  @Column()
+  @Column({ unique: true })
   nickname: string;
 
   @Column()

--- a/backend/src/auth/user.repository.ts
+++ b/backend/src/auth/user.repository.ts
@@ -22,7 +22,11 @@ export class UserRepository {
       await this.userRepository.save(newUser);
     } catch (error) {
       if (error.code === "23505") {
-        throw new ConflictException("이미 등록된 이메일입니다.");
+        if (error.detail.includes("email")) {
+          throw new ConflictException("이미 등록된 이메일입니다.");
+        } else if (error.detail.includes("nickname")) {
+          throw new ConflictException("이미 등록된 닉네임입니다.");
+        }
       } else {
         throw new InternalServerErrorException();
       }

--- a/backend/src/bet-room/bet-room.controller.ts
+++ b/backend/src/bet-room/bet-room.controller.ts
@@ -9,6 +9,7 @@ import {
   Res,
   Param,
   UseGuards,
+  Delete,
 } from "@nestjs/common";
 import { BetRoomService } from "./bet-room.service";
 import { Response } from "express";
@@ -144,6 +145,29 @@ export class BetRoomController {
         status: HttpStatus.OK,
         data: {
           channel: betRoomData,
+          message: "OK",
+        },
+      });
+    } catch (error) {
+      return res.status(error.status || HttpStatus.INTERNAL_SERVER_ERROR).json({
+        status: error.status || HttpStatus.INTERNAL_SERVER_ERROR,
+        data: {
+          message: error.message || "Internal Server Error",
+        },
+      });
+    }
+  }
+
+  @UseGuards(JwtGuestAuthGuard)
+  @Delete("/:betRoomId")
+  async deleteBetRoom(
+    @Param("betRoomId") betRoomId: string,
+    @Res() res: Response,
+  ) {
+    try {
+      return res.status(HttpStatus.OK).json({
+        status: HttpStatus.OK,
+        data: {
           message: "OK",
         },
       });

--- a/backend/src/bet-room/bet-room.controller.ts
+++ b/backend/src/bet-room/bet-room.controller.ts
@@ -158,13 +158,16 @@ export class BetRoomController {
     }
   }
 
-  @UseGuards(JwtGuestAuthGuard)
+  @UseGuards(JwtUserAuthGuard)
   @Delete("/:betRoomId")
   async deleteBetRoom(
     @Param("betRoomId") betRoomId: string,
+    @Req() req: Request,
     @Res() res: Response,
   ) {
     try {
+      const userId = req["user"].id;
+      await this.betRoomService.deleteBetRoom(betRoomId, userId);
       return res.status(HttpStatus.OK).json({
         status: HttpStatus.OK,
         data: {

--- a/backend/src/bet-room/bet-room.repository.ts
+++ b/backend/src/bet-room/bet-room.repository.ts
@@ -39,4 +39,12 @@ export class BetRoomRepository {
       );
     }
   }
+
+  async delete(betRoomId: string): Promise<void> {
+    try {
+      await this.betRoomRepository.delete(betRoomId);
+    } catch {
+      throw new InternalServerErrorException("베팅 방 삭제에 실패했습니다");
+    }
+  }
 }

--- a/backend/src/bet-room/bet-room.service.ts
+++ b/backend/src/bet-room/bet-room.service.ts
@@ -56,7 +56,7 @@ export class BetRoomService {
     betRoomId: string,
     updateBetRoomDto: UpdateBetRoomDto,
   ): Promise<void> {
-    this.assertBetRoomAccess(betRoomId, userId);
+    await this.assertBetRoomAccess(betRoomId, userId);
 
     const updatedFields: Partial<BetRoom> = {};
     if (updateBetRoomDto.channel?.title) {
@@ -75,7 +75,7 @@ export class BetRoomService {
   }
 
   async startBetRoom(userId: number, betRoomId: string) {
-    this.assertBetRoomAccess(betRoomId, userId);
+    await this.assertBetRoomAccess(betRoomId, userId);
 
     const updateResult = await this.betRoomRepository.update(betRoomId, {
       status: "active",
@@ -91,7 +91,7 @@ export class BetRoomService {
     betRoomId: string,
     winningOption: "option1" | "option2",
   ) {
-    this.assertBetRoomAccess(betRoomId, userId);
+    await this.assertBetRoomAccess(betRoomId, userId);
 
     const updateResult = await this.betRoomRepository.update(betRoomId, {
       status: "finished",
@@ -166,6 +166,17 @@ export class BetRoomService {
     };
   }
 
+  async deleteBetRoom(betRoomId: string, userId: number): Promise<void> {
+    const betRoom = await this.betRoomRepository.findOneById(betRoomId);
+    await this.assertBetRoomAccess(betRoomId, userId);
+
+    if (betRoom && betRoom.status !== "waiting") {
+      throw new ForbiddenException("베팅룸의 상태가 waiting이 아닙니다.");
+    }
+    await this.betRoomRepository.delete(betRoomId);
+    await this.redisManager.deleteChannelData(betRoomId);
+  }
+
   private async getBettingTotals(betRoomId: string) {
     const channel = await this.redisManager.getChannelData(betRoomId);
     if (!channel) {
@@ -210,7 +221,7 @@ export class BetRoomService {
       throw new NotFoundException("베팅 방을 찾을 수 없습니다.");
     }
     if (betRoom.manager.id !== userId) {
-      throw new ForbiddenException("베팅 방에 접근할 권한이 없습니다.");
+      throw new ForbiddenException("접근 권한이 없습니다.");
     }
   }
 


### PR DESCRIPTION
## 🔍 이슈

## 📗 작업 내역

> 구현한 작업 내역
1. 베팅룸 삭제 API 구현
2. 베팅방 검증 메서드 await 처리
3. 회원 엔티티 명 user -> users 로 수정
4. 회원 가입 시 이메일, 닉네임 중복 처리 분리
5. DB 초기화

## 📋 PR 유형

- [X] 기능 추가
- [X] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않은 변경 사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 파일 혹은 폴더 추가

## ⚠️ 추가적으로 설명할 내용
postgresql 테이블 초기화