### PR TITLE
[FE] 승부예측 결과 결정 기능 구현

### DIFF
--- a/frontend/src/features/betting-page-admin/index.tsx
+++ b/frontend/src/features/betting-page-admin/index.tsx
@@ -226,9 +226,7 @@ function BettingPageAdmin() {
                 "투표가 진행 중입니다. 투표를 취소할 수 있습니다."
               ) : (
                 <>
-                  투표가 종료되었습니다.
-                  <br /> 투표를 취소하거나 종료할 수 있습니다. <br /> 투표를
-                  취소하게 되면{" "}
+                  투표를 취소하게 되면{" "}
                   <span className="text-bettingPink font-extrabold">
                     모든 베팅 금액이 환불되고 베팅이 종료되며, 돌이킬 수
                     없습니다.

--- a/frontend/src/features/betting-page-admin/index.tsx
+++ b/frontend/src/features/betting-page-admin/index.tsx
@@ -222,9 +222,19 @@ function BettingPageAdmin() {
               {title}
             </h1>
             <p>
-              {status === "active"
-                ? "투표가 진행 중입니다. 투표를 취소할 수 있습니다."
-                : "투표가 종료되었습니다. 투표를 취소하거나 종료할 수 있습니다."}
+              {status === "active" ? (
+                "투표가 진행 중입니다. 투표를 취소할 수 있습니다."
+              ) : (
+                <>
+                  투표가 종료되었습니다.
+                  <br /> 투표를 취소하거나 종료할 수 있습니다. <br /> 투표를
+                  취소하게 되면{" "}
+                  <span className="text-bettingPink font-extrabold">
+                    모든 베팅 금액이 환불되고 베팅이 종료되며, 돌이킬 수
+                    없습니다.
+                  </span>
+                </>
+              )}
             </p>
             <h1 className="text-default-disabled text-md mb-1 font-bold">
               베팅 정보

--- a/frontend/src/features/decide-betting-result/api/endBetRoom.ts
+++ b/frontend/src/features/decide-betting-result/api/endBetRoom.ts
@@ -1,0 +1,46 @@
+interface EndBetRoomResponse {
+  status: number;
+  data: {
+    bet_room_id?: string;
+    message: string;
+  };
+}
+export async function endBetRoom(
+  betRoomId: string,
+  winningOption: "option1" | "option2",
+): Promise<string> {
+  try {
+    const response = await fetch(`/api/betrooms/end/${betRoomId}`, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        winning_option: winningOption,
+      }),
+    });
+
+    const responseData: EndBetRoomResponse = await response.json();
+
+    if (response.ok) {
+      console.log("배팅 종료 성공:", responseData.data.message);
+      return responseData.data.message;
+    }
+
+    if (response.status === 401) {
+      console.error("인증되지 않은 사용자:", responseData.data.message);
+      throw new Error(responseData.data.message);
+    }
+
+    if (response.status === 403) {
+      console.error("접근 권한이 없음:", responseData.data.message);
+      throw new Error(responseData.data.message);
+    }
+
+    console.error("알 수 없는 오류:", responseData.data.message);
+    throw new Error("Unexpected error: " + responseData.data.message);
+  } catch (error) {
+    console.error("요청 실패:", error);
+    throw new Error("Failed to end bet room. Please try again.");
+  }
+}

--- a/frontend/src/features/decide-betting-result/index.tsx
+++ b/frontend/src/features/decide-betting-result/index.tsx
@@ -1,8 +1,9 @@
 import { DuckCoinIcon } from "@/shared/icons";
 import { useBettingContext } from "../betting-page/hook/useBettingContext";
 import { calculateWinnings, calculateOdds } from "@/shared/utils/bettingOdds";
-import { endBetRoom } from "../betting-page/api/endBetroom";
+import { endBetRoom } from "./api/endBetRoom";
 import { getBettingRoomInfo } from "../betting-page/api/getBettingRoomInfo";
+import { useNavigate } from "@tanstack/react-router";
 
 interface BettingPool {
   totalAmount: number;
@@ -88,21 +89,42 @@ function BettingResult({
 function DecideBettingResult() {
   const { bettingPool, bettingRoomInfo } = useBettingContext();
   const { channel } = bettingRoomInfo;
+  const navigate = useNavigate();
+
+  console.log(bettingPool);
+  const handleDecideClick = async (option: "option1" | "option2") => {
+    try {
+      const roomId = channel.id;
+      const message = await endBetRoom(roomId, option);
+      console.log(message);
+      navigate({ to: `/betting/${roomId}/vote/resultDetail` });
+    } catch (error) {
+      if (error instanceof Error) {
+        console.error("API 요청 실패:", error.message);
+      } else {
+        console.error("알 수 없는 오류 발생");
+      }
+    }
+  };
 
   return (
-    <div className={"bg-layout-main h-full w-full rounded-lg p-6"}>
+    <div
+      className={
+        "bg-layout-main flex h-full w-full flex-col justify-center gap-10 rounded-lg p-6"
+      }
+    >
       <button
         onClick={async () => {
           const a = await getBettingRoomInfo(channel.id);
           console.log(a);
         }}
       >
-        dd
+        정보 출력 버튼
       </button>
-      <h1 className="w-full text-center text-lg font-bold">
+      <h1 className="w-full text-center text-2xl font-bold">
         승리한 팀을 선택 해주세요!
       </h1>
-      <div className="flex h-full flex-row items-center">
+      <div className="flex flex-row items-center">
         <div className="flex w-[50cqw] flex-col items-center gap-6">
           <BettingResult
             uses="winning"
@@ -110,9 +132,9 @@ function DecideBettingResult() {
             content={channel.options.option1.name}
           />
           <button
-            className="bg-bettingBlue text-layout-main w-[40cqw] rounded-lg py-2"
+            className="bg-bettingBlue hover:bg-bettingBlue-behind hover:text-default text-layout-main w-[40cqw] rounded-lg py-2 hover:font-bold"
             type="submit"
-            onClick={() => endBetRoom(channel.id, "option1")}
+            onClick={() => handleDecideClick("option1")}
           >
             파란팀의 승리!
           </button>
@@ -124,8 +146,8 @@ function DecideBettingResult() {
             content={channel.options.option2.name}
           />
           <button
-            className="bg-bettingPink text-layout-main w-[40cqw] rounded-lg py-2"
-            onClick={() => endBetRoom(channel.id, "option2")}
+            className="bg-bettingPink hover:bg-bettingPink-disabled hover:text-default text-layout-main w-[40cqw] rounded-lg py-2 hover:font-bold"
+            onClick={() => handleDecideClick("option2")}
           >
             빨간팀의 승리!
           </button>

--- a/frontend/src/features/waiting-room/ui/AdminFooter/StartVotingButton.tsx
+++ b/frontend/src/features/waiting-room/ui/AdminFooter/StartVotingButton.tsx
@@ -12,7 +12,7 @@ function StartVotingButton() {
       });
       if (!response.ok) throw new Error("배팅 시작에 실패했습니다.");
       setIsBettingStarted(true);
-      navigate({ to: "../vote/voting" });
+      navigate({ to: "../vote/admin" });
     } catch (error) {
       console.error(error);
     }

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -18,10 +18,10 @@ import { Route as LoginImport } from "./routes/login";
 import { Route as CreateVoteImport } from "./routes/create-vote";
 import { Route as IndexImport } from "./routes/index";
 import { Route as BettingIndexImport } from "./routes/betting.index";
-import { Route as PredictDetailUserTypeImport } from "./routes/predict-detail.$userType";
 import { Route as BettingRoomIdWaitingImport } from "./routes/betting_.$roomId.waiting";
 import { Route as BettingRoomIdVoteImport } from "./routes/betting_.$roomId.vote";
 import { Route as BettingRoomIdVoteVotingImport } from "./routes/betting_.$roomId.vote.voting";
+import { Route as BettingRoomIdVoteResultDetailImport } from "./routes/betting_.$roomId.vote.resultDetail";
 import { Route as BettingRoomIdVoteDecideImport } from "./routes/betting_.$roomId.vote.decide";
 import { Route as BettingRoomIdVoteAdminImport } from "./routes/betting_.$roomId.vote.admin";
 
@@ -69,12 +69,6 @@ const BettingIndexRoute = BettingIndexImport.update({
   getParentRoute: () => rootRoute,
 } as any);
 
-const PredictDetailUserTypeRoute = PredictDetailUserTypeImport.update({
-  id: "/predict-detail/$userType",
-  path: "/predict-detail/$userType",
-  getParentRoute: () => rootRoute,
-} as any);
-
 const BettingRoomIdWaitingRoute = BettingRoomIdWaitingImport.update({
   id: "/betting_/$roomId/waiting",
   path: "/betting/$roomId/waiting",
@@ -92,6 +86,13 @@ const BettingRoomIdVoteVotingRoute = BettingRoomIdVoteVotingImport.update({
   path: "/voting",
   getParentRoute: () => BettingRoomIdVoteRoute,
 } as any);
+
+const BettingRoomIdVoteResultDetailRoute =
+  BettingRoomIdVoteResultDetailImport.update({
+    id: "/resultDetail",
+    path: "/resultDetail",
+    getParentRoute: () => BettingRoomIdVoteRoute,
+  } as any);
 
 const BettingRoomIdVoteDecideRoute = BettingRoomIdVoteDecideImport.update({
   id: "/decide",
@@ -151,13 +152,6 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof RequireRoomIdImport;
       parentRoute: typeof rootRoute;
     };
-    "/predict-detail/$userType": {
-      id: "/predict-detail/$userType";
-      path: "/predict-detail/$userType";
-      fullPath: "/predict-detail/$userType";
-      preLoaderRoute: typeof PredictDetailUserTypeImport;
-      parentRoute: typeof rootRoute;
-    };
     "/betting/": {
       id: "/betting/";
       path: "/betting";
@@ -193,6 +187,13 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof BettingRoomIdVoteDecideImport;
       parentRoute: typeof BettingRoomIdVoteImport;
     };
+    "/betting_/$roomId/vote/resultDetail": {
+      id: "/betting_/$roomId/vote/resultDetail";
+      path: "/resultDetail";
+      fullPath: "/betting/$roomId/vote/resultDetail";
+      preLoaderRoute: typeof BettingRoomIdVoteResultDetailImport;
+      parentRoute: typeof BettingRoomIdVoteImport;
+    };
     "/betting_/$roomId/vote/voting": {
       id: "/betting_/$roomId/vote/voting";
       path: "/voting";
@@ -208,12 +209,14 @@ declare module "@tanstack/react-router" {
 interface BettingRoomIdVoteRouteChildren {
   BettingRoomIdVoteAdminRoute: typeof BettingRoomIdVoteAdminRoute;
   BettingRoomIdVoteDecideRoute: typeof BettingRoomIdVoteDecideRoute;
+  BettingRoomIdVoteResultDetailRoute: typeof BettingRoomIdVoteResultDetailRoute;
   BettingRoomIdVoteVotingRoute: typeof BettingRoomIdVoteVotingRoute;
 }
 
 const BettingRoomIdVoteRouteChildren: BettingRoomIdVoteRouteChildren = {
   BettingRoomIdVoteAdminRoute: BettingRoomIdVoteAdminRoute,
   BettingRoomIdVoteDecideRoute: BettingRoomIdVoteDecideRoute,
+  BettingRoomIdVoteResultDetailRoute: BettingRoomIdVoteResultDetailRoute,
   BettingRoomIdVoteVotingRoute: BettingRoomIdVoteVotingRoute,
 };
 
@@ -227,12 +230,12 @@ export interface FileRoutesByFullPath {
   "/my-page": typeof MyPageRoute;
   "/require-login": typeof RequireLoginRoute;
   "/require-roomId": typeof RequireRoomIdRoute;
-  "/predict-detail/$userType": typeof PredictDetailUserTypeRoute;
   "/betting": typeof BettingIndexRoute;
   "/betting/$roomId/vote": typeof BettingRoomIdVoteRouteWithChildren;
   "/betting/$roomId/waiting": typeof BettingRoomIdWaitingRoute;
   "/betting/$roomId/vote/admin": typeof BettingRoomIdVoteAdminRoute;
   "/betting/$roomId/vote/decide": typeof BettingRoomIdVoteDecideRoute;
+  "/betting/$roomId/vote/resultDetail": typeof BettingRoomIdVoteResultDetailRoute;
   "/betting/$roomId/vote/voting": typeof BettingRoomIdVoteVotingRoute;
 }
 
@@ -243,12 +246,12 @@ export interface FileRoutesByTo {
   "/my-page": typeof MyPageRoute;
   "/require-login": typeof RequireLoginRoute;
   "/require-roomId": typeof RequireRoomIdRoute;
-  "/predict-detail/$userType": typeof PredictDetailUserTypeRoute;
   "/betting": typeof BettingIndexRoute;
   "/betting/$roomId/vote": typeof BettingRoomIdVoteRouteWithChildren;
   "/betting/$roomId/waiting": typeof BettingRoomIdWaitingRoute;
   "/betting/$roomId/vote/admin": typeof BettingRoomIdVoteAdminRoute;
   "/betting/$roomId/vote/decide": typeof BettingRoomIdVoteDecideRoute;
+  "/betting/$roomId/vote/resultDetail": typeof BettingRoomIdVoteResultDetailRoute;
   "/betting/$roomId/vote/voting": typeof BettingRoomIdVoteVotingRoute;
 }
 
@@ -260,12 +263,12 @@ export interface FileRoutesById {
   "/my-page": typeof MyPageRoute;
   "/require-login": typeof RequireLoginRoute;
   "/require-roomId": typeof RequireRoomIdRoute;
-  "/predict-detail/$userType": typeof PredictDetailUserTypeRoute;
   "/betting/": typeof BettingIndexRoute;
   "/betting_/$roomId/vote": typeof BettingRoomIdVoteRouteWithChildren;
   "/betting_/$roomId/waiting": typeof BettingRoomIdWaitingRoute;
   "/betting_/$roomId/vote/admin": typeof BettingRoomIdVoteAdminRoute;
   "/betting_/$roomId/vote/decide": typeof BettingRoomIdVoteDecideRoute;
+  "/betting_/$roomId/vote/resultDetail": typeof BettingRoomIdVoteResultDetailRoute;
   "/betting_/$roomId/vote/voting": typeof BettingRoomIdVoteVotingRoute;
 }
 
@@ -278,12 +281,12 @@ export interface FileRouteTypes {
     | "/my-page"
     | "/require-login"
     | "/require-roomId"
-    | "/predict-detail/$userType"
     | "/betting"
     | "/betting/$roomId/vote"
     | "/betting/$roomId/waiting"
     | "/betting/$roomId/vote/admin"
     | "/betting/$roomId/vote/decide"
+    | "/betting/$roomId/vote/resultDetail"
     | "/betting/$roomId/vote/voting";
   fileRoutesByTo: FileRoutesByTo;
   to:
@@ -293,12 +296,12 @@ export interface FileRouteTypes {
     | "/my-page"
     | "/require-login"
     | "/require-roomId"
-    | "/predict-detail/$userType"
     | "/betting"
     | "/betting/$roomId/vote"
     | "/betting/$roomId/waiting"
     | "/betting/$roomId/vote/admin"
     | "/betting/$roomId/vote/decide"
+    | "/betting/$roomId/vote/resultDetail"
     | "/betting/$roomId/vote/voting";
   id:
     | "__root__"
@@ -308,12 +311,12 @@ export interface FileRouteTypes {
     | "/my-page"
     | "/require-login"
     | "/require-roomId"
-    | "/predict-detail/$userType"
     | "/betting/"
     | "/betting_/$roomId/vote"
     | "/betting_/$roomId/waiting"
     | "/betting_/$roomId/vote/admin"
     | "/betting_/$roomId/vote/decide"
+    | "/betting_/$roomId/vote/resultDetail"
     | "/betting_/$roomId/vote/voting";
   fileRoutesById: FileRoutesById;
 }
@@ -325,7 +328,6 @@ export interface RootRouteChildren {
   MyPageRoute: typeof MyPageRoute;
   RequireLoginRoute: typeof RequireLoginRoute;
   RequireRoomIdRoute: typeof RequireRoomIdRoute;
-  PredictDetailUserTypeRoute: typeof PredictDetailUserTypeRoute;
   BettingIndexRoute: typeof BettingIndexRoute;
   BettingRoomIdVoteRoute: typeof BettingRoomIdVoteRouteWithChildren;
   BettingRoomIdWaitingRoute: typeof BettingRoomIdWaitingRoute;
@@ -338,7 +340,6 @@ const rootRouteChildren: RootRouteChildren = {
   MyPageRoute: MyPageRoute,
   RequireLoginRoute: RequireLoginRoute,
   RequireRoomIdRoute: RequireRoomIdRoute,
-  PredictDetailUserTypeRoute: PredictDetailUserTypeRoute,
   BettingIndexRoute: BettingIndexRoute,
   BettingRoomIdVoteRoute: BettingRoomIdVoteRouteWithChildren,
   BettingRoomIdWaitingRoute: BettingRoomIdWaitingRoute,
@@ -360,7 +361,6 @@ export const routeTree = rootRoute
         "/my-page",
         "/require-login",
         "/require-roomId",
-        "/predict-detail/$userType",
         "/betting/",
         "/betting_/$roomId/vote",
         "/betting_/$roomId/waiting"
@@ -384,9 +384,6 @@ export const routeTree = rootRoute
     "/require-roomId": {
       "filePath": "require-roomId.tsx"
     },
-    "/predict-detail/$userType": {
-      "filePath": "predict-detail.$userType.tsx"
-    },
     "/betting/": {
       "filePath": "betting.index.tsx"
     },
@@ -395,6 +392,7 @@ export const routeTree = rootRoute
       "children": [
         "/betting_/$roomId/vote/admin",
         "/betting_/$roomId/vote/decide",
+        "/betting_/$roomId/vote/resultDetail",
         "/betting_/$roomId/vote/voting"
       ]
     },
@@ -407,6 +405,10 @@ export const routeTree = rootRoute
     },
     "/betting_/$roomId/vote/decide": {
       "filePath": "betting_.$roomId.vote.decide.tsx",
+      "parent": "/betting_/$roomId/vote"
+    },
+    "/betting_/$roomId/vote/resultDetail": {
+      "filePath": "betting_.$roomId.vote.resultDetail.tsx",
       "parent": "/betting_/$roomId/vote"
     },
     "/betting_/$roomId/vote/voting": {

--- a/frontend/src/routes/betting_.$roomId.vote.resultDetail.tsx
+++ b/frontend/src/routes/betting_.$roomId.vote.resultDetail.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { PredictDetail } from "@/features/predict-detail";
+
+export const Route = createFileRoute("/betting_/$roomId/vote/resultDetail")({
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  return <PredictDetail />;
+}

--- a/frontend/src/routes/predict-detail.$userType.tsx
+++ b/frontend/src/routes/predict-detail.$userType.tsx
@@ -1,6 +1,0 @@
-import { createFileRoute } from "@tanstack/react-router";
-import { PredictDetail } from "@/features/predict-detail";
-
-export const Route = createFileRoute("/predict-detail/$userType")({
-  component: PredictDetail,
-});

--- a/frontend/src/shared/components/BettingStatsDisplay/BettingStatsDisplay.tsx
+++ b/frontend/src/shared/components/BettingStatsDisplay/BettingStatsDisplay.tsx
@@ -36,9 +36,7 @@ const BettingStatsDisplay = React.memo(
     );
 
     return (
-      <div
-        className={`flex flex-1 flex-row justify-between pl-8 pr-4 ${color}`}
-      >
+      <div className={`flex flex-1 flex-row justify-between ${color}`}>
         <div className="text-md flex max-w-[35cqw] flex-col gap-2">
           {bettingStats.map(({ icon: Icon, alt, stat }) => (
             <div

--- a/frontend/src/shared/components/PercentageDisplay/PercentageDisplay.tsx
+++ b/frontend/src/shared/components/PercentageDisplay/PercentageDisplay.tsx
@@ -21,7 +21,7 @@ const PercentageDisplay = React.memo(function PercentageDisplay({
       <ProgressBar
         value={percentage}
         uses={index === 0 ? "winning" : "losing"}
-        className="w-[30cqw] -scale-x-100"
+        className="w-full -scale-x-100"
       />
     </div>
   );


### PR DESCRIPTION
## 🔍 이슈
[#60]

## 📗 작업 내역
- waiting 페이지에서 투표 시작 누른 사람이 관리자라면 바로 관리자 페이지로 이동 되게끔 구현
- 덕배 빠져나가는 문제 수정
- 투표 취소 경고문 수정
- 승부 예측 결과 페이지 라우팅
- 승부 예측 결과 결정 기능 구현

## 📋 PR 유형

- [x] 기능 추가
- [ ] 버그 수정
- [x] UI 디자인 변경
- [ ] 코드에 영향을 주지 않은 변경 사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [x] 파일 혹은 폴더 삭제
- [x] 파일 혹은 폴더 추가

## ⚠️ 추가적으로 설명할 내용
