### PR TITLE
[FE] 승부 결과 상세 보기 페이지 퍼블리싱 및 일부 기능 구현

### DIFF
--- a/frontend/src/features/betting-page-admin/index.tsx
+++ b/frontend/src/features/betting-page-admin/index.tsx
@@ -209,6 +209,30 @@ function BettingPageAdmin() {
     });
   };
 
+  const handleBetOption1 = () => {
+    socket.emit("joinBet", {
+      sender: {
+        betAmount: 100,
+        selectOption: "option1",
+      },
+      channel: {
+        roomId,
+      },
+    });
+  };
+
+  const handleBetOption2 = () => {
+    socket.emit("joinBet", {
+      sender: {
+        betAmount: 100,
+        selectOption: "option2",
+      },
+      channel: {
+        roomId,
+      },
+    });
+  };
+
   return (
     <div className="bg-layout-main flex h-full w-full flex-col justify-between">
       <div className="flex flex-col gap-5">
@@ -295,6 +319,8 @@ function BettingPageAdmin() {
           </div>
         </div>
       </div>
+      <button onClick={handleBetOption1}>투표1</button>
+      <button onClick={handleBetOption2}>투표2</button>
       <BettingSharedLink />
     </div>
   );

--- a/frontend/src/features/predict-detail/index.tsx
+++ b/frontend/src/features/predict-detail/index.tsx
@@ -1,18 +1,77 @@
 import { PeoplesIcon, DuckCoinIcon, TrophyIcon } from "@/shared/icons";
 import { ProgressBar } from "@/shared/components/ProgressBar";
 import { UserFooter } from "./ui/UserFooter";
+import { useBettingContext } from "../betting-page/hook/useBettingContext";
+import { useContext, useEffect, useState } from "react";
+import { UserContext } from "@/app/provider/UserProvider";
+import { GuestFooter } from "./ui/GuestFooter";
+
+interface BetResultResponse {
+  status: number;
+  data: {
+    option_1_total_bet: string;
+    option_2_total_bet: string;
+    option_1_total_participants: string;
+    option_2_total_participants: string;
+    winning_option: "option1" | "option2";
+    message: string;
+  };
+  error?: string;
+}
 
 function PredictDetail() {
+  const { bettingRoomInfo } = useBettingContext();
+  const { channel } = bettingRoomInfo;
+  const [betResults, setBetResults] = useState<BetResultResponse>({
+    status: 200,
+    data: {
+      option_1_total_bet: "0",
+      option_2_total_bet: "0",
+      option_1_total_participants: "0",
+      option_2_total_participants: "0",
+      winning_option: "option1",
+      message: "Loading...",
+    },
+  });
+  const userContext = useContext(UserContext);
+  const { role } = userContext?.userInfo || {};
+
+  useEffect(() => {
+    const fetchBetResults = async () => {
+      try {
+        const response = await fetch(`/api/betresults/${channel.id}`, {
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+          },
+        });
+
+        const data: BetResultResponse = await response.json();
+
+        if (response.ok) {
+          console.log(data);
+          setBetResults(data);
+        } else {
+          console.log(data.error);
+        }
+      } catch (err) {
+        console.error("Error fetching bet results:", err);
+      }
+    };
+
+    fetchBetResults();
+  }, []);
+
   return (
     <div className="bg-layout-main flex h-full w-full flex-col items-center justify-between gap-4">
       {/* PredictDetail Header */}
       <div className="bg-primary shadow-middle flex w-[90cqw] flex-col items-center justify-center rounded-2xl px-4 py-4">
         <div className="text-layout-main text-lg font-extrabold">
-          <span>KBO 우승은 KIA다!</span>
+          <span>{channel.title}</span>
         </div>
         <h1 className="text-layout-main flex items-center gap-4 text-2xl font-extrabold">
           <TrophyIcon className="font-extrabold" width={32} height={32} />
-          승리 : KIA
+          승리 : {channel.options[betResults.data.winning_option].name}
         </h1>
       </div>
 
@@ -26,28 +85,40 @@ function PredictDetail() {
             <div className="flex flex-row items-center gap-2">
               <PeoplesIcon className="text-default" />총 참여자
             </div>
-            <span>159 명</span>
+            <span>
+              {betResults.data.option_1_total_participants +
+                betResults.data.option_2_total_participants}
+              명
+            </span>
           </div>
           <div>
             <div className="flex justify-between">
-              <span className="font-bold">KIA</span>
-              <span className="font-extrabold">89명</span>
+              <span className="font-bold">{channel.options.option1.name}</span>
+              <span className="font-extrabold">
+                {betResults.data.option_1_total_participants}명
+              </span>
             </div>
             <ProgressBar
-              max={159}
-              value={89}
+              max={Number(
+                betResults.data.option_1_total_participants +
+                  betResults.data.option_2_total_participants,
+              )}
+              value={Number(betResults.data.option_1_total_participants)}
               uses={"winning"}
               label="승리에 참여한 사용자 비율"
             />
           </div>
           <div>
             <div className="flex justify-between font-extrabold">
-              <span className="font-bold">삼성</span>
-              <span>70명</span>
+              <span className="font-bold">{channel.options.option2.name}</span>
+              <span>{betResults.data.option_2_total_participants}명</span>
             </div>
             <ProgressBar
-              max={159}
-              value={50}
+              max={Number(
+                betResults.data.option_1_total_participants +
+                  betResults.data.option_2_total_participants,
+              )}
+              value={Number(betResults.data.option_2_total_participants)}
               uses={"losing"}
               label="패배에 참여한 사용자 비율"
             />
@@ -65,37 +136,63 @@ function PredictDetail() {
         <div className="flex flex-col gap-2 pt-4">
           <div className="flex justify-between">
             <div className="flex flex-row items-center gap-2">
-              <DuckCoinIcon
-                className="text-bettingBlue"
-                width={24}
-                height={24}
-              />
+              {betResults.data.winning_option === "option1" ? (
+                <DuckCoinIcon
+                  className="text-bettingBlue"
+                  width={24}
+                  height={24}
+                />
+              ) : (
+                <DuckCoinIcon
+                  className="text-bettingPink"
+                  width={24}
+                  height={24}
+                />
+              )}
               배팅 금액
             </div>
             <span className="text-default font-extrabold">300 포인트</span>
           </div>
           <div className="flex justify-between">
             <span>선택 옵션</span>
-            <span className="text-bettingBlue font-extrabold">KIA</span>
+            {betResults.data.winning_option === "option1" ? (
+              <span className="text-bettingBlue font-extrabold">
+                {channel.options.option1.name}
+              </span>
+            ) : (
+              <span className="text-bettingPink font-extrabold">
+                {channel.options.option2.name}
+              </span>
+            )}
           </div>
           <div className="flex justify-between">
             <span>얻은 금액</span>
-            <div className="text-bettingBlue flex flex-row gap-2 font-extrabold">
-              <DuckCoinIcon
-                className="text-bettingBlue"
-                width={24}
-                height={24}
-              />
-              + 300 코인
-            </div>
+            {betResults.data.winning_option === "option1" ? (
+              <div className="text-bettingBlue flex flex-row gap-2 font-extrabold">
+                <DuckCoinIcon
+                  className="text-bettingBlue"
+                  width={24}
+                  height={24}
+                />
+                + 300 코인
+              </div>
+            ) : (
+              <div className="text-bettingPink flex flex-row gap-2 font-extrabold">
+                <DuckCoinIcon
+                  className="text-bettingPink"
+                  width={24}
+                  height={24}
+                />
+                + 300 코인
+              </div>
+            )}
           </div>
         </div>
       </div>
 
       {/* PredictDetail footer */}
       <div className="flex w-[90cqw] flex-col gap-2 pt-8">
-        <UserFooter />
-        {/* {userType === "user" ? <UserFooter /> : <GuestFooter />} */}
+        {role === "guest" ? <GuestFooter /> : <UserFooter />}
       </div>
       <div className="h-[60px] w-[100cqw] bg-[#e6edf8]" />
     </div>

--- a/frontend/src/features/predict-detail/index.tsx
+++ b/frontend/src/features/predict-detail/index.tsx
@@ -5,6 +5,8 @@ import { useBettingContext } from "../betting-page/hook/useBettingContext";
 import { useContext, useEffect, useState } from "react";
 import { UserContext } from "@/app/provider/UserProvider";
 import { GuestFooter } from "./ui/GuestFooter";
+import { BettingResult } from "./ui/UserBettingResult";
+import { AdminBettingResult } from "./ui/AdminBettingResult";
 
 interface BetResultResponse {
   status: number;
@@ -60,7 +62,27 @@ function PredictDetail() {
     };
 
     fetchBetResults();
-  }, []);
+  }, [channel.id]);
+
+  // Utility functions
+  const getWinningOptionName = () =>
+    channel.options[betResults.data.winning_option].name;
+
+  const getTotalParticipants = () =>
+    Number(betResults.data.option_1_total_participants) +
+    Number(betResults.data.option_2_total_participants);
+
+  const renderWinningIcon = () => (
+    <DuckCoinIcon
+      className={
+        betResults.data.winning_option === "option1"
+          ? "text-bettingBlue"
+          : "text-bettingPink"
+      }
+      width={24}
+      height={24}
+    />
+  );
 
   return (
     <div className="bg-layout-main flex h-full w-full flex-col items-center justify-between gap-4">
@@ -71,7 +93,7 @@ function PredictDetail() {
         </div>
         <h1 className="text-layout-main flex items-center gap-4 text-2xl font-extrabold">
           <TrophyIcon className="font-extrabold" width={32} height={32} />
-          승리 : {channel.options[betResults.data.winning_option].name}
+          승리 : {getWinningOptionName()}
         </h1>
       </div>
 
@@ -85,11 +107,7 @@ function PredictDetail() {
             <div className="flex flex-row items-center gap-2">
               <PeoplesIcon className="text-default" />총 참여자
             </div>
-            <span>
-              {betResults.data.option_1_total_participants +
-                betResults.data.option_2_total_participants}
-              명
-            </span>
+            <span>{getTotalParticipants()}명</span>
           </div>
           <div>
             <div className="flex justify-between">
@@ -99,10 +117,7 @@ function PredictDetail() {
               </span>
             </div>
             <ProgressBar
-              max={Number(
-                betResults.data.option_1_total_participants +
-                  betResults.data.option_2_total_participants,
-              )}
+              max={getTotalParticipants()}
               value={Number(betResults.data.option_1_total_participants)}
               uses={"winning"}
               label="승리에 참여한 사용자 비율"
@@ -114,10 +129,7 @@ function PredictDetail() {
               <span>{betResults.data.option_2_total_participants}명</span>
             </div>
             <ProgressBar
-              max={Number(
-                betResults.data.option_1_total_participants +
-                  betResults.data.option_2_total_participants,
-              )}
+              max={getTotalParticipants()}
               value={Number(betResults.data.option_2_total_participants)}
               uses={"losing"}
               label="패배에 참여한 사용자 비율"
@@ -127,68 +139,20 @@ function PredictDetail() {
       </div>
 
       {/* PredictDetail result */}
-      <div className="bg-secondary w-[90cqw] rounded-lg px-8 py-4 shadow-inner">
-        <div>
-          <h2 className="flex flex-row items-center gap-2 text-lg font-extrabold">
-            배팅 결과
-          </h2>
-        </div>
-        <div className="flex flex-col gap-2 pt-4">
-          <div className="flex justify-between">
-            <div className="flex flex-row items-center gap-2">
-              {betResults.data.winning_option === "option1" ? (
-                <DuckCoinIcon
-                  className="text-bettingBlue"
-                  width={24}
-                  height={24}
-                />
-              ) : (
-                <DuckCoinIcon
-                  className="text-bettingPink"
-                  width={24}
-                  height={24}
-                />
-              )}
-              배팅 금액
-            </div>
-            <span className="text-default font-extrabold">300 포인트</span>
-          </div>
-          <div className="flex justify-between">
-            <span>선택 옵션</span>
-            {betResults.data.winning_option === "option1" ? (
-              <span className="text-bettingBlue font-extrabold">
-                {channel.options.option1.name}
-              </span>
-            ) : (
-              <span className="text-bettingPink font-extrabold">
-                {channel.options.option2.name}
-              </span>
-            )}
-          </div>
-          <div className="flex justify-between">
-            <span>얻은 금액</span>
-            {betResults.data.winning_option === "option1" ? (
-              <div className="text-bettingBlue flex flex-row gap-2 font-extrabold">
-                <DuckCoinIcon
-                  className="text-bettingBlue"
-                  width={24}
-                  height={24}
-                />
-                + 300 코인
-              </div>
-            ) : (
-              <div className="text-bettingPink flex flex-row gap-2 font-extrabold">
-                <DuckCoinIcon
-                  className="text-bettingPink"
-                  width={24}
-                  height={24}
-                />
-                + 300 코인
-              </div>
-            )}
-          </div>
-        </div>
-      </div>
+      {role === "admin" ? (
+        <AdminBettingResult
+          winningOption="option1"
+          winner={getWinningOptionName()}
+          winnerCount={Number(betResults.data.option_1_total_participants)}
+        />
+      ) : (
+        <BettingResult
+          renderWinningIcon={renderWinningIcon}
+          winningOption={betResults.data.winning_option}
+          options={channel.options}
+          earnedAmount={300}
+        />
+      )}
 
       {/* PredictDetail footer */}
       <div className="flex w-[90cqw] flex-col gap-2 pt-8">

--- a/frontend/src/features/predict-detail/model/api.ts
+++ b/frontend/src/features/predict-detail/model/api.ts
@@ -1,0 +1,48 @@
+interface BetResultResponseSuccess {
+  status: 200;
+  data: {
+    option_1_total_bet: string;
+    option_2_total_bet: string;
+    option_1_total_participants: string;
+    option_2_total_participants: string;
+    winning_option: "option1" | "option2";
+    message: string;
+  };
+}
+
+interface BetResultResponseError {
+  status: 404;
+  data: {
+    message: string;
+  };
+}
+
+type BetResultResponse = BetResultResponseSuccess | BetResultResponseError;
+
+export async function getBetResults(
+  betRoomId: string,
+): Promise<BetResultResponse> {
+  try {
+    const response = await fetch(`/api/betresults/${betRoomId}`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    const responseData: BetResultResponse = await response.json();
+
+    if (response.ok) {
+      return responseData;
+    }
+
+    if (response.status === 404) {
+      throw new Error(responseData.data.message);
+    }
+
+    throw new Error("Unexpected response status: " + response.status);
+  } catch (error) {
+    console.error("요청 실패:", error);
+    throw new Error("Failed to fetch bet results. Please try again.");
+  }
+}

--- a/frontend/src/features/predict-detail/ui/AdminBettingResult.tsx
+++ b/frontend/src/features/predict-detail/ui/AdminBettingResult.tsx
@@ -1,0 +1,40 @@
+interface BettingResultAdminProps {
+  winningOption: "option1" | "option2";
+  winner: string;
+  winnerCount: number;
+}
+function AdminBettingResult({
+  winningOption,
+  winner,
+  winnerCount,
+}: BettingResultAdminProps) {
+  return (
+    <div className="bg-secondary w-[90cqw] rounded-lg px-8 py-4 shadow-inner">
+      <div>
+        <h2 className="flex flex-row items-center gap-2 text-lg font-extrabold">
+          배팅 결과(관리자)
+        </h2>
+      </div>
+      <div className="flex flex-col gap-2 pt-4">
+        <div className="flex justify-between">
+          <div className="flex flex-row items-center gap-2">승리 팀</div>
+          {winningOption === "option1" ? (
+            <span className="text-bettingBlue font-extrabold">{winner}</span>
+          ) : (
+            <span className="text-bettingPink font-extrabold">{winner}</span>
+          )}
+        </div>
+        <div className="flex justify-between">
+          <span>승리 팀이 얻은 포인트</span>
+          <span>{winnerCount * 100}</span>
+        </div>
+        <div className="flex justify-between">
+          <span>승리 인원</span>
+          <span>{winnerCount}명</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export { AdminBettingResult };

--- a/frontend/src/features/predict-detail/ui/GuestFooter.tsx
+++ b/frontend/src/features/predict-detail/ui/GuestFooter.tsx
@@ -1,11 +1,21 @@
 import React from "react";
 import { Image } from "@/shared/components/Image";
 import userPlusImage from "@/assets/images/user-plus.png";
+import { useNavigate } from "@tanstack/react-router";
 
 function GuestFooter() {
+  const navigate = useNavigate();
+
+  const handleJoinClick = () => {
+    navigate({ to: "/login" });
+  };
+
   return (
     <React.Fragment>
-      <button className="bg-default text-layout-main flex w-full items-center justify-center gap-4 rounded-lg py-2 text-lg font-extrabold">
+      <button
+        className="bg-default text-layout-main flex w-full items-center justify-center gap-4 rounded-lg py-2 text-lg font-extrabold"
+        onClick={handleJoinClick}
+      >
         <Image
           src={userPlusImage}
           width={24}

--- a/frontend/src/features/predict-detail/ui/UserBettingResult.tsx
+++ b/frontend/src/features/predict-detail/ui/UserBettingResult.tsx
@@ -1,0 +1,70 @@
+import { DuckCoinIcon } from "@/shared/icons";
+
+interface BettingResultProps {
+  renderWinningIcon: () => React.ReactNode;
+  winningOption: "option1" | "option2";
+  options: {
+    option1: { name: string };
+    option2: { name: string };
+  };
+  earnedAmount: number; // 얻은 금액
+}
+
+export const BettingResult: React.FC<BettingResultProps> = ({
+  renderWinningIcon,
+  winningOption,
+  options,
+  earnedAmount,
+}) => {
+  return (
+    <div className="bg-secondary w-[90cqw] rounded-lg px-8 py-4 shadow-inner">
+      <div>
+        <h2 className="flex flex-row items-center gap-2 text-lg font-extrabold">
+          배팅 결과
+        </h2>
+      </div>
+      <div className="flex flex-col gap-2 pt-4">
+        <div className="flex justify-between">
+          <div className="flex flex-row items-center gap-2">
+            {renderWinningIcon()} 배팅 금액
+          </div>
+          <span className="text-default font-extrabold">300 포인트</span>
+        </div>
+        <div className="flex justify-between">
+          <span>선택 옵션</span>
+          {winningOption === "option1" ? (
+            <span className="text-bettingBlue font-extrabold">
+              {options.option1.name}
+            </span>
+          ) : (
+            <span className="text-bettingPink font-extrabold">
+              {options.option2.name}
+            </span>
+          )}
+        </div>
+        <div className="flex justify-between">
+          <span>얻은 금액</span>
+          {winningOption === "option1" ? (
+            <div className="text-bettingBlue flex flex-row gap-2 font-extrabold">
+              <DuckCoinIcon
+                className="text-bettingBlue"
+                width={24}
+                height={24}
+              />
+              + {earnedAmount} 코인
+            </div>
+          ) : (
+            <div className="text-bettingPink flex flex-row gap-2 font-extrabold">
+              <DuckCoinIcon
+                className="text-bettingPink"
+                width={24}
+                height={24}
+              />
+              + {earnedAmount} 코인
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/features/predict-detail/ui/UserFooter.tsx
+++ b/frontend/src/features/predict-detail/ui/UserFooter.tsx
@@ -1,10 +1,28 @@
+import { useNavigate } from "@tanstack/react-router";
+
 function UserFooter() {
+  const navigate = useNavigate();
+
+  const handleMyPageClick = () => {
+    navigate({ to: "/my-page" });
+  };
+
+  const handleCreateClick = () => {
+    navigate({ to: "/create-vote" });
+  };
+
   return (
     <div className="flex w-full items-center justify-around gap-4">
-      <button className="bg-default text-layout-main w-full rounded-lg px-4 py-2 text-lg font-extrabold">
+      <button
+        className="bg-default text-layout-main w-full rounded-lg px-4 py-2 text-lg font-extrabold"
+        onClick={handleMyPageClick}
+      >
         마이페이지로 돌아가기
       </button>
-      <button className="bg-default text-layout-main w-full rounded-lg px-4 py-2 text-lg font-extrabold">
+      <button
+        className="bg-default text-layout-main w-full rounded-lg px-4 py-2 text-lg font-extrabold"
+        onClick={handleCreateClick}
+      >
         방 생성하러 가기
       </button>
     </div>

--- a/frontend/src/routes/betting_.$roomId.vote.resultDetail.tsx
+++ b/frontend/src/routes/betting_.$roomId.vote.resultDetail.tsx
@@ -1,10 +1,15 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { PredictDetail } from "@/features/predict-detail";
+import { UserProvider } from "@/app/provider/UserProvider";
 
 export const Route = createFileRoute("/betting_/$roomId/vote/resultDetail")({
   component: RouteComponent,
 });
 
 function RouteComponent() {
-  return <PredictDetail />;
+  return (
+    <UserProvider>
+      <PredictDetail />
+    </UserProvider>
+  );
 }


### PR DESCRIPTION
## 🔍 이슈
#59 

## 📗 작업 내역
- `role`에 따른 footer 렌더링 구현
- footer 버튼 누르면 해당 페이지로 이동되게끔 구현
- 관리자 페이지 테스트용 코드 작성
- 관리자용/사용자용 베팅 결과 페이지 구현

## 📸 스크린샷
<img width="995" alt="image" src="https://github.com/user-attachments/assets/a2110c6a-2b7f-46d2-acb0-0ccab5f88686">


## 📋 PR 유형

- [x] 기능 추가
- [ ] 버그 수정
- [x] UI 디자인 변경
- [ ] 코드에 영향을 주지 않은 변경 사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [x] 파일 혹은 폴더 추가

## ⚠️ 추가적으로 설명할 내용
- 관리자가 투표를 생성하고, 취소 혹은 종료하고, 결과를 결정하고 최종 페이지에서 원하는 동작을 하는 모든 과정이 구현되어있습니다. 현재 `bettingPool`에 제대로 된 정보가 업데이트 되지 않는 문제를 정민님께서 해결해주시면 되고, 결과 상세 페이지에 추가적인 구현이 필요한 상태지만 동작 자체는 무리 없이 시연 가능합니다!! 정민님께서 사용자 페이지에서 연결만 해주시면 될 것 같고, 정 안 되겠으면 링크로 들어가도 `role`에 따라 문제없이 화면이 렌더링 됩니다. **넘 무리하지 마시고 편한대로 보여주세요!!** 저희에겐 주말이 있으니까요!
- API 부분 코드 일단은 대충 된다고 생각하고 구현한 거라 추후에 추가적인 에러 핸들링이 필요합니다.
- 현재 결과 상세 페이지에서 필요한 정보는 **"내가 어느 옵션을 골랐는가/얼마를 투자했는가/얼마를 얻거나 잃었는가"** 입니다. 동교님께 이 정보를 보내주실 수 있겠냐 여쭸는데 어떻게 될 지 한 번 봐야될 것 같다고 말씀해주셨습니다. 현재로써는 구현이 어려운 것 같아서 일단 상수값을 넣어둔 상태입니다. - `UserBettingResult` 부분
- `AdminBettingResult` : 아래의 디자인을 참고하여 승리 팀, 승리 팀이 얻은 포인트, 승리 인원을 넣어두었습니다. 정확히 어떤 식으로 계산해야하는지 몰라서 정확한 정보 대신 해당 정보들을 넣어둔 점 참고 부탁드립니다.
<img width="363" alt="image" src="https://github.com/user-attachments/assets/52470396-876f-472b-a0e9-981a324a44ed">

- 현재 관리자 페이지에서 비율이 잘못 계산되는 이슈가 있습니다.
<img width="500" alt="image" src="https://github.com/user-attachments/assets/23aa9300-50eb-47c5-ad16-4140fcdf10ee">

