### PR TITLE
[FE] 승부예측 관리자 페이지 중복 요청 안 날리게 최적화

### DIFF
--- a/frontend/src/features/betting-page-admin/index.tsx
+++ b/frontend/src/features/betting-page-admin/index.tsx
@@ -114,23 +114,6 @@ function BettingPageAdmin() {
   // }, [socket, updateBettingPool, updateBettingRoomInfo]);
 
   // useEffect(() => {
-  //   if (!socket.isConnected) return;
-  //   socket.emit("joinRoom", {
-  //     channel: {
-  //       roomId: bettingRoomInfo.channel.id,
-  //     },
-  //   });
-  // }, [socket, bettingRoomInfo]);
-
-  // useEffect(() => {
-  //   if (!socket.isConnected || bettingRoomInfo.channel.status !== "active")
-  //     return;
-  //   socket.emit("fetchBetRoomInfo", {
-  //     roomId: bettingRoomInfo.channel.id,
-  //   });
-  // }, [socket, bettingRoomInfo]);
-
-  // useEffect(() => {
   //   console.log(bettingRoomInfo.channel.status);
   //   setStatus((prev) => {
   //     if (prev !== bettingRoomInfo.channel.status) {
@@ -215,25 +198,6 @@ function BettingPageAdmin() {
   //     socket.off("fetchBetRoomInfo");
   //   };
   // }, [socket, bettingRoomInfo, updateBettingPool]);
-
-  // useEffect(() => {
-  //   const fetchData = async () => {
-  //     try {
-  //       const response = await fetch(`/api/betrooms/${roomId}`);
-  //       if (response.ok) {
-  //         const { data } = await response.json();
-  //         setTitle(data.channel.title);
-  //         setOption1(data.channel.options.option1.name);
-  //         setOption2(data.channel.options.option2.name);
-  //         setTimer(data.channel.settings.duration);
-  //         setDefaultBetAmount(data.channel.settings.defaultBetAmount);
-  //       }
-  //     } catch (error) {
-  //       console.error(error);
-  //     }
-  //   };
-  //   if (roomId) fetchData();
-  // }, [roomId]);
 
   const handleCancelClick = async () => {
     refund(roomId)

--- a/frontend/src/features/betting-page-admin/index.tsx
+++ b/frontend/src/features/betting-page-admin/index.tsx
@@ -1,6 +1,6 @@
 import { BettingStatsDisplay } from "@/shared/components/BettingStatsDisplay/BettingStatsDisplay";
 import { useLoaderData, useNavigate } from "@tanstack/react-router";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useSocketIO } from "@/shared/hooks/useSocketIo";
 import { BettingSummary } from "@/shared/utils/bettingOdds";
 import { BettingTimer } from "@/shared/components/BettingTimer/BettingTimer";
@@ -56,7 +56,9 @@ function BettingPageAdmin() {
   const defaultBetAmount = channel.settings.defaultBetAmount;
   const timer = channel.settings.duration;
 
-  const [status] = useState(bettingRoomInfo.channel.status || "active");
+  const [status, setStatus] = useState(
+    bettingRoomInfo.channel.status || "active",
+  );
   const navigate = useNavigate();
   const joinRoomRef = useRef(false);
   const fetchBetRoomInfoRef = useRef(false);
@@ -102,16 +104,24 @@ function BettingPageAdmin() {
     }
   }, [channel.id, bettingRoomInfo.channel.status, socket]);
 
-  // useEffect(() => {
-  //   socket.on("timeover", () => {
-  //     updateBettingRoomInfo();
-  //     updateBettingPool({ isBettingEnd: true });
-  //   });
+  const handleTimeOver = useCallback(() => {
+    setStatus((prev) => {
+      if (prev !== "timeover") {
+        return "timeover";
+      }
+      return prev;
+    });
+  }, []);
 
-  //   return () => {
-  //     socket.off("timeover");
-  //   };
-  // }, [socket, updateBettingPool, updateBettingRoomInfo]);
+  useEffect(() => {
+    if (!socket) return;
+    console.log("timeover");
+    socket.on("timeover", handleTimeOver);
+
+    return () => {
+      socket.off("timeover");
+    };
+  }, [socket]);
 
   // useEffect(() => {
   //   console.log(bettingRoomInfo.channel.status);

--- a/frontend/src/features/betting-page-admin/model/api.ts
+++ b/frontend/src/features/betting-page-admin/model/api.ts
@@ -19,25 +19,3 @@ export async function refund(betRoomId: string) {
     throw error;
   }
 }
-
-export async function finish(betRoomId: string) {
-  try {
-    const response = await fetch(`/api/betrooms/end/${betRoomId}`, {
-      method: "PATCH",
-      headers: {
-        "Content-Type": "application/json",
-      },
-    });
-
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
-
-    const data = await response.json();
-    console.log("종료 요청 성공:", data);
-    return data;
-  } catch (error) {
-    console.error("종료 요청 실패:", error);
-    throw error;
-  }
-}

--- a/frontend/src/routes/betting.index.tsx
+++ b/frontend/src/routes/betting.index.tsx
@@ -41,6 +41,9 @@ function RouteComponent() {
         throw new Error("방 정보를 파싱하는데 실패했습니다.");
 
       const { channel } = result.data;
+      if (channel.isAdmin) {
+        return navigate({ to: `/betting/${roomId}/vote/admin` });
+      }
       if (channel.status === "active") {
         return navigate({
           to: `/betting/${roomId}/vote/voting`,

--- a/frontend/src/routes/betting_.$roomId.vote.admin.tsx
+++ b/frontend/src/routes/betting_.$roomId.vote.admin.tsx
@@ -1,6 +1,44 @@
 import { BettingPageAdmin } from "@/features/betting-page-admin";
 import { createFileRoute } from "@tanstack/react-router";
+import { loadBetRoomData } from "@/shared/lib/loader/useBetRoomLoader";
+import { queryClient } from "@/shared/lib/auth/authQuery";
+import {
+  responseBetRoomInfo,
+  responseUserInfoSchema,
+} from "@betting-duck/shared";
+import { z } from "zod";
+import { getBettingRoomInfo } from "@/features/betting-page/api/getBettingRoomInfo";
+import { STORAGE_KEY } from "@/features/betting-page/model/var";
+
+type BetRoomResponse = z.infer<typeof responseBetRoomInfo>;
+type UserInfo = z.infer<typeof responseUserInfoSchema>;
+
+interface RouteLoaderData {
+  roomId: string;
+  bettingRoomInfo: BetRoomResponse;
+  userInfo: UserInfo;
+}
 
 export const Route = createFileRoute("/betting_/$roomId/vote/admin")({
   component: BettingPageAdmin,
+  loader: async ({ params, abortController }): Promise<RouteLoaderData> => {
+    const { roomId } = params;
+
+    const { bettingRoomInfo, userInfo } = await loadBetRoomData({
+      roomId,
+      signal: abortController.signal,
+      queryClient,
+    });
+
+    return { roomId, bettingRoomInfo, userInfo };
+  },
+  onLeave: async ({ params }) => {
+    const { roomId } = params;
+    const bettingRoomInfo = await getBettingRoomInfo(roomId);
+
+    if (bettingRoomInfo?.channel.status !== "active") {
+      console.log(bettingRoomInfo);
+      return sessionStorage.removeItem(STORAGE_KEY);
+    }
+  },
 });


### PR DESCRIPTION
## 🔍 이슈
#59 

## 📗 작업 내역
- admin Router에 loader 추가
- 관리자페이지 소켓 연결 최적화
- 불필요한 코드 삭제
- 사용되지 않는 API 함수 삭제
- 채팅방이 종료되면 status값 변하도록 구현
- 승부예측 변화에 따른 렌더링

## 📋 PR 유형

- [x] 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않은 변경 사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [x] 파일 혹은 폴더 삭제
- [ ] 파일 혹은 폴더 추가

## ⚠️ 추가적으로 설명할 내용
